### PR TITLE
Fixed errors showing up in valgrind.

### DIFF
--- a/Backend/src/date.cpp
+++ b/Backend/src/date.cpp
@@ -119,6 +119,12 @@ tm Date::tmDate() {
     date.tm_year = this->year;
     date.tm_mon = this->month - 1; // zero index
     date.tm_mday = this->day;
+    date.tm_hour = 0;
+    date.tm_min = 0;
+    date.tm_wday = 0;
+    date.tm_yday = 0;
+    date.tm_sec = 0;
+    date.tm_isdst = 0;
 
     return date;
 }


### PR DESCRIPTION
Caused by not a fully init tm date struct
even though hours/mins/sec were never used.